### PR TITLE
Event tracking

### DIFF
--- a/components/input-date-range.html
+++ b/components/input-date-range.html
@@ -6,18 +6,27 @@
     <input id="input-date-range-{{ id }}-min" type="date"
       min="{{ min && min.toISODate ? min.toISODate() : min }}"
       max="{{ max && max.toISODate ? max.toISODate() : max }}"
-      bind:value="minValue">
+      bind:value="minValue" on:input="track()">
 
       <label for="input-date-range-{{ id }}-min" class="sr-only">Maximum date</label>
     <input id="input-date-range-{{ id }}-max" type="date"
       min="{{ min && min.toISODate ? min.toISODate() : min }}"
       max="{{ max && max.toISODate ? max.toISODate() : max }}"
-      bind:value="maxValue">
+      bind:value="maxValue" on:input="track()">
   </div>
 </div>
 
 <script>
 export default {
+  methods: {
+    track() {
+      // Track with GA
+      gtag('event', 'date_filter', {
+        'event_label': this.get('minValue') + ' -> ' + this.get('maxValue'),
+      });
+    }
+  },
+
   oncreate: function() {
     // Set default values.  Note that (in chrome) if you X out date
     // then seting value again doesn't matter
@@ -40,6 +49,6 @@ export default {
       id: Math.floor(Math.random() * 1000000),
       label: 'Date range'
     };
-  }
+  },
 };
 </script>

--- a/components/input-date-range.html
+++ b/components/input-date-range.html
@@ -19,9 +19,10 @@
 <script>
 export default {
   methods: {
+    // Track with GA (probably the right-er way in Svelte)
     track() {
-      // Track with GA
       gtag('event', 'date_filter', {
+        'event_category': 'camp_guide_2018',
         'event_label': this.get('minValue') + ' -> ' + this.get('maxValue'),
       });
     }

--- a/components/input-slider.html
+++ b/components/input-slider.html
@@ -16,6 +16,18 @@
 import slider from 'nouislider';
 
 export default {
+  methods: {
+
+    // Looks like this needs to be set up separately from the method in page.html,
+    // which handles the tracking of everything else.
+    track: function(event_name, event_label) {
+      gtag('event', event_name, {
+        'event_category': 'camp_guide_2018',
+        'event_label': event_label,
+      });
+    },
+  },
+
   oncreate: function() {
     // Initial slider
     this.slider = slider.create(this.refs.slider, {
@@ -56,12 +68,8 @@ export default {
 
     // Track on mouseup
     this.slider.on('end', () => {
-      let event_id = 'slider: ' + this.slider.target.innerText;
-
-      // Track with GA
-      gtag('event', 'slider_filter', {
-        'event_label': event_id,
-      });
+      let event_id = this.slider.target.innerText;
+      this.track('slider_filter', event_id)
     });
   },
 

--- a/components/input-slider.html
+++ b/components/input-slider.html
@@ -53,6 +53,16 @@ export default {
         maxValue: parseInt(v[1], 10)
       });
     });
+
+    // Track on mouseup
+    this.slider.on('end', () => {
+      let event_id = 'slider: ' + this.slider.target.innerText;
+
+      // Track with GA
+      gtag('event', 'slider_filter', {
+        'event_label': event_id,
+      });
+    });
   },
 
   data: () => {

--- a/components/page.html
+++ b/components/page.html
@@ -3,10 +3,10 @@
     <div class="hero">
         <div class="row">
             <div class="col col-100 col-md-25">
-            <img src="http://static.startribune.com/news/projects/all/2018-summer-camp-guide/assets/images/camp-guide-logo.svg" alt="Star Tribune summer camp guide logo">     
+            <img src="http://static.startribune.com/news/projects/all/2018-summer-camp-guide/assets/images/camp-guide-logo.svg" alt="Star Tribune summer camp guide logo">
             </div>
 
-            <div class="col col-100 col-md-75">    
+            <div class="col col-100 col-md-75">
             <h1>2018 Minnesota Summer Camp Guide</h1>
             <p class="lead">Kids can learn how to program robots, play chess,
               speak Chinese or dance hip-hop style, among other
@@ -193,6 +193,11 @@ export default {
 
       let current = this.getDeep(`filters.categories.${category}`);
       this.setDeep(`filters.categories.${category}`, !current);
+
+      // Track with GA
+      gtag('event', 'activity_filter', {
+        'event_label': `filters.categories.${category}`,
+      });
     },
 
     searchAddress: function(e, address) {
@@ -225,6 +230,12 @@ export default {
           addressFound: results[0].formatted_address,
           isGeocoding: false
         });
+
+        // Track with GA
+        gtag('event', 'location_search', {
+          'event_label': 'searched',
+        });
+
       });
     }
   },

--- a/components/page.html
+++ b/components/page.html
@@ -24,7 +24,7 @@
         <div class="filters">
 
           <div class="row">
-              
+
             <div class="col col-100 col-md-33">
             <label class="activities">Activities</label>
               <div class="category-filter-wrapper">
@@ -73,19 +73,19 @@
                 <label class="top-label">Stay types</label>
 
                 <div class="checkbox-set">
-                    <input type="checkbox" id="filter-type-half" bind:checked="filters.type.half">
+                    <input type="checkbox" id="filter-type-half" bind:checked="filters.type.half" on:click="track('type_filter', 'half_day')">
                     <label for="filter-type-half">Half day</label><br>
 
-                    <input type="checkbox" id="filter-type-full" bind:checked="filters.type.full">
+                    <input type="checkbox" id="filter-type-full" bind:checked="filters.type.full" on:click="track('type_filter', 'full_day')">
                     <label for="filter-type-full">Full day</label><br>
 
-                    <input type="checkbox" id="filter-type-extended" bind:checked="filters.type.extended">
+                    <input type="checkbox" id="filter-type-extended" bind:checked="filters.type.extended" on:click="track('type_filter', 'extended_day')">
                     <label for="filter-type-extended">Extended day</label><br>
 
-                    <input type="checkbox" id="filter-type-overnight" bind:checked="filters.type.overnight">
+                    <input type="checkbox" id="filter-type-overnight" bind:checked="filters.type.overnight" on:click="track('type_filter', 'overnight')">
                     <label for="filter-type-overnight">Overnight</label><br>
 
-                    <input type="checkbox" id="filter-type-other" bind:checked="filters.type.other">
+                    <input type="checkbox" id="filter-type-other" bind:checked="filters.type.other" on:click="track('type_filter', 'other')">
                     <label for="filter-type-other">Other</label>
                 </div>
                 </div>
@@ -186,6 +186,14 @@ export default {
     setDeep,
     getDeep,
 
+    // Track with GA
+    track: function(event_name, event_label) {
+      gtag('event', event_name, {
+        'event_category': 'camp_guide_2018',
+        'event_label': event_label,
+      });
+    },
+
     categoryCheck: function(e, category) {
       if (e && e.preventDefault) {
         e.preventDefault();
@@ -194,10 +202,7 @@ export default {
       let current = this.getDeep(`filters.categories.${category}`);
       this.setDeep(`filters.categories.${category}`, !current);
 
-      // Track with GA
-      gtag('event', 'activity_filter', {
-        'event_label': `filters.categories.${category}`,
-      });
+      this.track('activity_filter', `filters.categories.${category}`)
     },
 
     searchAddress: function(e, address) {
@@ -231,11 +236,9 @@ export default {
           isGeocoding: false
         });
 
-        // Track with GA
-        gtag('event', 'location_search', {
-          'event_label': 'searched',
-        });
-
+        // Deliberately not tracking what people are searching for because that
+        // seems kinda weird and unnecessary.
+        this.track('location_filter', 'searched')
       });
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5688,10 +5688,7 @@
     "full-icu": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.2.0.tgz",
-      "integrity": "sha512-0B/oH/5WnTM0grN0/F91WN1zdLx+IKH0uOlAqj6DWhRQTGFCj645elI46fKykRSWeafPrIOIRzAL7co1Vku5pQ==",
-      "requires": {
-        "icu4c-data": "0.60.2"
-      }
+      "integrity": "sha512-0B/oH/5WnTM0grN0/F91WN1zdLx+IKH0uOlAqj6DWhRQTGFCj645elI46fKykRSWeafPrIOIRzAL7co1Vku5pQ=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -6970,11 +6967,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
-    },
-    "icu4c-data": {
-      "version": "0.60.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.60.2.tgz",
-      "integrity": "sha512-4ScORTYJPIDJRPtAkQWXfKqGk8u1ThOxFWCJ3jkq+rj/MU4cK6isCvhFiEjunivw1/bJ10LqNAaJ9pAK68DEZg=="
     },
     "ieee754": {
       "version": "1.1.8",

--- a/pages/index.ejs.html
+++ b/pages/index.ejs.html
@@ -7,6 +7,16 @@
   <body class="">
     <div class="article-lcd-body-content"></div><!-- end article-lcd-body-content -->
 
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-114906116-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-114906116-1');
+    </script>
+
     <!-- Global/external scripts -->
     <% if (config.js && config.js.globals) { config.js.globals.forEach(function(s) { %>
       <script src="<%= s %>"></script>


### PR DESCRIPTION
This drops a few GA tracking calls into the filters, so we can see what actually gets used. Might be helpful for next year, but also sets an example of something that we (as an organization) should be doing more often.

Code isn't as clean as it could be. Super redundant, not consistently organized, and some of the tracking calls (particularly the sliders) have weird values. But it'll get the job done, and we can definitely clean up next time. A few ideas for that, if we keep going down this road:

  * Use config.json to store things like the GA code and event_category
  * Use some kind of inheritance or global function to ensure track() only has to be implemented once.
  * Write some docs to explain when/how to drop tracking calls in the right places

I've tested all this using gulp develop --no-cms, so worth double-checking that it works alright once the CMS shell is included. If not, we can yank it. Confirmed that tracking calls are registering in GA.

And for reference, our GA account is [here](https://analytics.google.com/analytics/web/#embed/report-home/a114906116w170878863p170628372/). You should have access.

Holler if you have questions!

Thanks,
Chase