### PR TITLE
Don't fire slider tracking on movement, only on end

### DIFF
--- a/components/input-slider.html
+++ b/components/input-slider.html
@@ -54,7 +54,6 @@ export default {
         maxValue: parseInt(v[1], 10)
       });
 
-      this.track(`slider_filter ${this.get('label')}`, `${v[0]}-${v[1]}`);
     });
 
     // Track


### PR DESCRIPTION
Existing implementation has event tracking rapid-firing as the slider is moved. This fires the event tracker only when a slider is released.