### PR TITLE
Map minimization

### DIFF
--- a/components/input-slider.html
+++ b/components/input-slider.html
@@ -46,20 +46,24 @@ export default {
     // React to component changes
 
     // React to slier changes
-    this.slider.on('update', () => {
+    // this.slider.on('update', () => {
+    //   let v = this.slider.get();
+
+    //   this.set({
+    //     minValue: parseInt(v[0], 10),
+    //     maxValue: parseInt(v[1], 10)
+    //   });
+    // });
+
+    // Track
+    this.slider.on('end', () => {
       let v = this.slider.get();
 
       this.set({
         minValue: parseInt(v[0], 10),
         maxValue: parseInt(v[1], 10)
       });
-
-      this.track(`slider_filter ${this.get('label')}`, `${v[0]}-${v[1]}`);
-    });
-
-    // Track
-    this.slider.on('end', () => {
-      let v = this.slider.get();
+      
       this.track(`slider_filter ${this.get('label')}`, `${v[0]}-${v[1]}`);
     });
   },

--- a/components/lazyload.html
+++ b/components/lazyload.html
@@ -1,3 +1,0 @@
-<div class="lazyload-include">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/8.6.0/lazyload.min.js"></script>
-</div>

--- a/components/lazyload.html
+++ b/components/lazyload.html
@@ -1,0 +1,3 @@
+<div class="lazyload-include">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/8.6.0/lazyload.min.js"></script>
+</div>

--- a/components/page.html
+++ b/components/page.html
@@ -679,7 +679,7 @@ export default {
     return {
       isBrowser: typeof window != 'undefined',
       page: 1,
-      perPage: typeof window != 'undefined' ? 25 : 99999,
+      perPage: typeof window != 'undefined' ? 15 : 99999,
       addressInput: '',
       addressFound: '',
       showFilter: null,


### PR DESCRIPTION
This is a just-in-case pull request that does a couple simple things to allow us to reduce the number of Mapbox API calls. Namely, it:

  * Reduces the number of entries on the main page to 15
  * Only activates the sliders on mouseup (right now, when you slide the sliders, it's firing off a bunch of new mapbox calls in the background).

The next step would be implementing something like [LazyLoad](https://github.com/verlok/lazyload), which is literally like one line of code, but I can't figure out how to get it to work in the load order of the app.

I'm going to ask for Jeff's Mapbox logins to keep an eye on the running cost. But one catch is that I don't know how to deploy this code should we need to do it. So any guidance on that front would be appreciated.